### PR TITLE
Migrate module setup to uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .vscode/
+uv.lock
+visualization-env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 uv.lock
 visualization-env
+.venv

--- a/03_instructional_team/markdown_slides/01_course_intro.md
+++ b/03_instructional_team/markdown_slides/01_course_intro.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Introduction and Overview
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 
 ---

--- a/03_instructional_team/markdown_slides/02_getting_started_matplotlib.md
+++ b/03_instructional_team/markdown_slides/02_getting_started_matplotlib.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Introduction and Overview
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 
 ---

--- a/03_instructional_team/markdown_slides/03_reproducible.md
+++ b/03_instructional_team/markdown_slides/03_reproducible.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Reproducible Data Visualization
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 
 ---

--- a/03_instructional_team/markdown_slides/04_choosing_the_right_visualization.md
+++ b/03_instructional_team/markdown_slides/04_choosing_the_right_visualization.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Choosing the Right Visualization
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 
 ---

--- a/03_instructional_team/markdown_slides/05_customizing_our_plots.md
+++ b/03_instructional_team/markdown_slides/05_customizing_our_plots.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Customizing Our Plots
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 
 ---

--- a/03_instructional_team/markdown_slides/06_subplots_and_combining_viz.md
+++ b/03_instructional_team/markdown_slides/06_subplots_and_combining_viz.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Subplots and Combining Visualizations
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 ---
 

--- a/03_instructional_team/markdown_slides/07_accessible_data_visualization.md
+++ b/03_instructional_team/markdown_slides/07_accessible_data_visualization.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Visualization with Purpose - Accessible Data Visualization
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 ---
 

--- a/03_instructional_team/markdown_slides/08_data_viz_as_advocacy.md
+++ b/03_instructional_team/markdown_slides/08_data_viz_as_advocacy.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Visualization with Purpose - Data Visualization as Advocacy
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 ---
 

--- a/03_instructional_team/markdown_slides/09_beyond_matplotlib.md
+++ b/03_instructional_team/markdown_slides/09_beyond_matplotlib.md
@@ -8,7 +8,7 @@ paginate: true
 # Data Visualization: Beyond Matplotlib
 
 ```code
-$ echo "Data Science Institute"
+$ echo "Data Sciences Institute"
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Participants are encouraged to engage actively during the learning module. They 
 * Participants must have a computer and an internet connection to participate in online activities.
 * Participants are expected to follow along with live coding.
 * Participants must not use generative AI such as ChatGPT to generate code in order to complete assignments. It should be used as a supportive tool to seek out answers to questions you may have.
-* We expect participants to have completed the steps in the [onboarding repo](https://github.com/UofT-DSI/onboarding/).
+* We expect participants to have completed the steps in the [onboarding repo](https://github.com/UofT-DSI/onboarding/blob/main/environment_setup/README.md).
 * We encourage participants to default to having their camera on at all times, and turning the camera off only as needed. This will greatly enhance the learning experience for all participants and provides real-time feedback for the instructional team. 
 
 ## Resources
@@ -111,6 +111,7 @@ Feel free to use the following as resources:
 ├── 04_cohort_three
 ├── .gitignore
 ├── LICENSE
+├── SETUP.md
 └── README.md
 ```
 
@@ -121,6 +122,7 @@ Feel free to use the following as resources:
 * **cohort_three**: Additional materials and resources for cohort three.
 * **.gitignore**: Files to exclude from this folder, specified by the Technical Facilitator
 * **LICENSE**: The license for this repository.
+* **SETUP.md**: Contains the instructions for creating and activating the environment, and installing any packages needed for this specific module.
 * **README.md**: This file.
 
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Feel free to use the following as resources:
 ├── .gitignore
 ├── LICENSE
 ├── SETUP.md
+├── pyproject.toml
 └── README.md
 ```
 
@@ -122,7 +123,8 @@ Feel free to use the following as resources:
 * **cohort_three**: Additional materials and resources for cohort three.
 * **.gitignore**: Files to exclude from this folder, specified by the Technical Facilitator
 * **LICENSE**: The license for this repository.
-* **SETUP.md**: Contains the instructions for creating and activating the environment, and installing any packages needed for this specific module.
+* **SETUP.md**: Contains the steps required to set up this repo for the module.
+* **pyproject.toml**: Tells Python which packages this repo needs to run.
 * **README.md**: This file.
 
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,65 @@
+# Setup
+## Environment Setup Guide
+Before using this repo, make sure you’ve completed the [environment setup guide](https://github.com/UofT-DSI/onboarding/blob/main/environment_setup/README.md), which installs the core tools you’ll need for this module, such as:
+
+- Git  
+- Git Bash (for Windows)  
+- Visual Studio Code
+- UV
+
+## Necessary Packages
+The Visualization module uses its own isolated environment called `visualization-env` so that packages don’t conflict with other projects. 
+We use UV to create this environment, activate it, and install the required packages listed in the module’s `pyproject.toml`.  
+
+Open a terminal (macOS/Linux) or Git Bash (Windows) in this repo, and run the following commands in order:
+
+1. Create a virtual environment called `visualization-env`:
+    ```
+    uv venv visualization-env --python 3.11
+    ```
+
+2. Activate the environment:
+    - for macOS/Linux:
+        ```
+        source visualization-env/bin/activate
+        ```
+        
+    - for windows (git bash):    
+        ```
+        source visualization-env/Scripts/activate
+        ```
+
+3. Install all required packages from the [pyproject.toml](./pyproject.toml)
+    ```bash
+    uv sync --active
+    ```
+
+## Environment Usage
+In order to run any code in this repo, you must first activate its environment.
+- for macOS/Linux:
+    ```
+    source visualization-env/bin/activate
+    ```
+    
+- for windows (git bash):    
+    ```
+    source visualization-env/Scripts/activate
+    ```
+
+When the environment is active, your terminal prompt will change to show:  
+```
+(visualization-env) $
+```
+This is your **visual cue** that you’re working inside the right environment.  
+
+When you’re finished, you can deactivate it with:  
+```bash
+deactivate
+```
+
+> **👉 Remember**   
+> Only one environment can be active at a time. If you switch to a different repo, first deactivate this one (or just close the terminal) and then activate the new repo’s environment.
+
+---
+
+For questions or issues, please contact the Visualization Module learning support team or email courses.dsi@utoronto.ca.

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,6 +10,7 @@ Before using this repo, make sure you’ve completed the [environment setup guid
 ## Necessary Packages
 The Visualization module uses its own isolated environment called `visualization-env` so that packages don’t conflict with other projects. 
 We use UV to create this environment, activate it, and install the required packages listed in the module’s `pyproject.toml`.  
+This setup only needs to be done **once per module**, after that, you just activate the environment whenever you want to work in this repo.  
 
 Open a terminal (macOS/Linux) or Git Bash (Windows) in this repo, and run the following commands in order:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "visualization-env"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "matplotlib>=3.10.6",
+    "numpy>=2.3.3",
+    "pandas>=2.3.2",
+    "seaborn>=0.13.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "visualization-env"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "ipykernel>=6.30.1",
     "matplotlib>=3.10.6",
     "numpy>=2.3.3",
     "pandas>=2.3.2",


### PR DESCRIPTION
This PR continues the migration away from Conda toward **uv** for environment and package management.  

### Changes  
- Added a `SETUP.md` file with instructions for creating, activating, and syncing the module’s environment using uv.  
- Added a minimal `pyproject.toml` to declare dependencies and enable reproducible installs with uv.  
- Updated `.gitignore` to exclude common junk files (e.g., virtual environments, lockfiles, cache directories).  
- Lightly updated any references to Conda usage in the content to reflect uv-based setup instead.